### PR TITLE
Integrate slideout.js with Filament navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,58 @@ $variable = new VendorName\Skeleton();
 echo $variable->echoPhrase('Hello, VendorName!');
 ```
 
+## Integration with Slideout.js
+
+To integrate Slideout.js with Filament's navigation, follow these steps:
+
+1. Install Slideout.js via npm or yarn:
+    ```bash
+    npm install slideout
+    ```
+
+2. Include the Slideout.js library in your project by adding it to your `resources/js/index.js`:
+    ```javascript
+    import Slideout from 'slideout';
+
+    document.addEventListener('DOMContentLoaded', function() {
+        var slideout = new Slideout({
+            'panel': document.getElementById('panel'),
+            'menu': document.getElementById('menu'),
+            'padding': 256,
+            'tolerance': 70
+        });
+
+        document.querySelector('.toggle-button').addEventListener('click', function() {
+            slideout.toggle();
+        });
+    });
+    ```
+
+3. Create a new JavaScript file to initialize Slideout.js and configure it to work with Filament's navigation.
+
+4. Update the Filament navigation template to include the necessary HTML structure for Slideout.js:
+    ```html
+    <div id="menu">
+        <!-- Your navigation items here -->
+    </div>
+
+    <div id="panel">
+        <button class="toggle-button">Toggle Menu</button>
+        <!-- Your main content here -->
+    </div>
+    ```
+
+5. Register the new JavaScript file as an asset in the `src/SkeletonServiceProvider.php` file:
+    ```php
+    protected function getAssets(): array
+    {
+        return [
+            // other assets
+            Js::make('slideout', __DIR__ . '/../resources/js/index.js'),
+        ];
+    }
+    ```
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "filament/filament": "^3.0",
         "filament/forms": "^3.0",
         "filament/tables": "^3.0",
-        "spatie/laravel-package-tools": "^1.15.0"
+        "spatie/laravel-package-tools": "^1.15.0",
+        "slideout": "^1.0.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -1,0 +1,14 @@
+import Slideout from 'slideout';
+
+document.addEventListener('DOMContentLoaded', function() {
+    var slideout = new Slideout({
+        'panel': document.getElementById('panel'),
+        'menu': document.getElementById('menu'),
+        'padding': 256,
+        'tolerance': 70
+    });
+
+    document.querySelector('.toggle-button').addEventListener('click', function() {
+        slideout.toggle();
+    });
+});

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -1,0 +1,8 @@
+<div id="menu">
+    <!-- Your navigation items here -->
+</div>
+
+<div id="panel">
+    <button class="toggle-button">Toggle Menu</button>
+    <!-- Your main content here -->
+</div>

--- a/src/SkeletonServiceProvider.php
+++ b/src/SkeletonServiceProvider.php
@@ -103,6 +103,7 @@ class SkeletonServiceProvider extends PackageServiceProvider
             // AlpineComponent::make('skeleton', __DIR__ . '/../resources/dist/components/skeleton.js'),
             Css::make('skeleton-styles', __DIR__ . '/../resources/dist/skeleton.css'),
             Js::make('skeleton-scripts', __DIR__ . '/../resources/dist/skeleton.js'),
+            Js::make('slideout', __DIR__ . '/../resources/js/index.js'), // Register the new JavaScript file as an asset
         ];
     }
 


### PR DESCRIPTION
Integrate Slideout.js with Filament's navigation in the plugin.

* **Add Slideout.js Dependency**
  - Modify `composer.json` to include `slideout` as a dependency.

* **Initialize Slideout.js**
  - Modify `resources/js/index.js` to import and initialize Slideout.js with Filament's navigation.

* **Register JavaScript Asset**
  - Modify `src/SkeletonServiceProvider.php` to register the new JavaScript file as an asset.

* **Update Navigation Template**
  - Add `resources/views/navigation.blade.php` to include the necessary HTML structure for Slideout.js.

* **Update Documentation**
  - Modify `README.md` to include instructions for integrating Slideout.js with Filament's navigation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreaskviby/mobile-slider-menu/pull/1?shareId=31d77d8a-47a0-416e-a6b4-4a534d1580ac).